### PR TITLE
Fix typo in README usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Here is an example of TSLA's volatility contraction pattern
 Usage Instructions
 batch mode:
 1. Run cookStockPipeline.py to perform both stage 2 template screening and apply contraction pattern detection on the selected stocks.
-2. Run cookstock_askgpt.py to perfrorm news extraction and gpt review.
+2. Run cookstock_askgpt.py to perform news extraction and gpt review.
    I have 2 ways to get news
    a. use scraper to scrapt news from yahoo finance
    b. use [finnhub](https://github.com/Finnhub-Stock-API/finnhub-python) to request news


### PR DESCRIPTION
## Summary
- fix typo "perfrorm" -> "perform" in README usage instructions

## Testing
- `grep -n perform README.md`